### PR TITLE
Add missing <cstdint> to cuvslam2.h

### DIFF
--- a/isaac_ros_nitros/lib/cuvslam/include/cuvslam/cuvslam2.h
+++ b/isaac_ros_nitros/lib/cuvslam/include/cuvslam/cuvslam2.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>


### PR DESCRIPTION
cuvslam2.h uses uint8_t, int32_t and friends (50 occurrences) but includes only <array>, <functional>, <memory>, <optional>, <string>, <string_view>, <unordered_map> and <vector>. The fixed-width integer types arrive only transitively, which GCC 13 happens to do and GCC 15 does not.

Compiling against the header with GCC 15 fails:

    cuvslam2.h:162:14: error: use of enum 'Model' without previous declaration
    cuvslam2.h:162:22: error: 'uint8_t' was not declared in this scope
    cuvslam2.h:162:30: error: default member initializer for unnamed bit-field
    cuvslam2.h:169:3:  error: 'Model' does not name a type
    cuvslam2.h:231:14: error: use of enum 'Encoding' without previous declaration

The sibling cuvslam.h already includes <cstdint>, so this looks like an oversight when the v2 header was introduced rather than a deliberate choice.

Found while building isaac_ros_visual_slam from source against a GCC 15 toolchain, where it is the only thing preventing the package from compiling.